### PR TITLE
Add CocoaPods installation instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,18 @@ Installation
 -----
 * Installation with CocoaPods
 
+```ruby
+source 'https://github.com/CocoaPods/Specs.git'
+platform :ios, '8.0'
+use_frameworks!
+
+pod 'TransporterSwift', '~> 0.1.1'
 ```
-	// coming soon
+
+Then run the following command:
+
+```sh
+pod install
 ```
 
 * Copying all the files into your project


### PR DESCRIPTION
**Note**: This might not be exactly what you want, but I found [Transporter on CocoaPods](https://cocoapods.org/pods/Transporter) and figured someone else might want to know it's there without straying from the readme.
